### PR TITLE
Fix Rails.logger use,  update default URL options

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
 
   # Settings specified here will take precedence over those in config/application.rb.
   config.action_mailer.default_url_options = {
-    host: "https://#{::Util.is_prod? ? 'members.manchestermakerspace.org' : 'makerspace-test.herokuapp.com'}",
+    host: "https://#{::Util.is_prod? ? 'members.manchestermakerspace.org' : 'members.manchestermakerspace.org'}",
     protocol: "https"
   }
   config.action_mailer.delivery_method = :smtp
@@ -10,52 +10,12 @@ Rails.application.configure do
   config.action_mailer.raise_delivery_errors = false
   config.action_mailer.default :charset => "utf-8"
 
+  warn "Warning: REDIS_DB is missing!" unless ENV['REDIS_DB']
   config.cache_store = :redis_store, {
     expires_in: 1.hour,
     namespace: 'cache',
     redis: { host: ENV['REDIS_URL'], port: ENV['REDIS_PORT'], db: ENV['REDIS_DB'] }
   }
-
-  if ::Util.is_prod?
-    config.action_mailer.smtp_settings = {
-      authentication: :plain,
-      address: 'smtp.gmail.com',
-      port: 587,
-      domain: 'makerspace-interface.herokuapp.com',
-      user_name: ENV['GMAIL_USERNAME'],
-      password: ENV['GMAIL_PASSWORD']
-    }
-  elsif ENV['MAILTRAP_API_TOKEN']
-    response = RestClient::Resource.new("https://mailtrap.io/api/v1/inboxes.json?api_token=#{ENV['MAILTRAP_API_TOKEN']}").get
-    inbox = JSON.parse(response)[0]
-    config.action_mailer.smtp_settings = {
-      :user_name => inbox['username'],
-      :password => inbox['password'],
-      :address => inbox['domain'],
-      :domain => inbox['domain'],
-      :port => 2525,
-      :authentication => :plain
-    }
-  end
-
-  # Code is not reloaded between requests.
-  config.cache_classes = true
-
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
-  config.eager_load = true
-
-  # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
-  config.action_controller.perform_caching = true
-
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-
-  # Compress JavaScripts and CSS.
   #config.assets.js_compressor = :uglifier
   #config.assets.css_compressor = :sass
 
@@ -65,9 +25,9 @@ Rails.application.configure do
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.action_controller.asset_host = config.action_mailer.default_url_options[:host]
+  # config.action_controller.asset_host = config.action_mailer.default_url_options[:host]
   config.action_mailer.asset_host = config.action_mailer.default_url_options[:host]
-  
+
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
@@ -114,7 +74,55 @@ Rails.application.configure do
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
+    Rails.logger = logger
+  else
+    Rails.logger = Logger.new(STDERR)
   end
+
+  if ENV['GMAIL_USERNAME'].present?
+    config.action_mailer.smtp_settings = {
+      authentication: :plain,
+      address: 'smtp.gmail.com',
+      port: 587,
+      domain: 'makerspace-interface.herokuapp.com',
+      user_name: ENV['GMAIL_USERNAME'],
+      password: ENV['GMAIL_PASSWORD']
+    }
+  elsif ENV['SMTP_USERNAME'].present?
+    config.action_mailer.smtp_settings = {
+      authentication: :login,
+      address: ENV['SMTP_ADDRESS'],
+      host: ENV['SMTP_ADDRESS'],
+      port: (ENV['SMTP_PORT'] || 587).to_i,
+      user_name: ENV['SMTP_USERNAME'],
+      password: ENV['SMTP_PASSWORD'],
+      enable_starttls_auto: true
+    }
+  else
+    config.action_mailer.perform_deliveries = false
+    Rails.logger.warn '[Mailer] WARNING: No mail provider configured — email delivery disabled'
+  end
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+  config.hosts << "members.manchestermakerspace.com"
+  config.hosts << "members.manchestermakerspace.org"
+  config.hosts << "makerspace-dev-51ba804d4c30.herokuapp.com"
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Compress JavaScripts and CSS.
 
   # Do not dump schema after migrations.
   # config.active_record.dump_schema_after_migration = false


### PR DESCRIPTION
Avoid the issue of using Rails.logger.warn before it is initialized